### PR TITLE
remove spinner from bootstrap

### DIFF
--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -74,4 +74,3 @@
 @import './block';
 @import './page';
 @import './common';
-@import './table';

--- a/src/assets/styles/table.scss
+++ b/src/assets/styles/table.scss
@@ -1,8 +1,0 @@
-.table {
-  &__loader {
-    font-size: 18px;
-    font-weight: 400;
-    padding: 20px 0;
-    color: $color-primary;
-  }
-}

--- a/src/components/TableLoader.vue
+++ b/src/components/TableLoader.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="table__loader text-center">
-    <b-spinner class="table__spinner align-middle"></b-spinner>
+  <div class="table-loader">
+    <font-awesome-icon
+      class="table-loader__sppiner"
+      size="2x"
+      icon="spinner"
+      spin
+    />
   </div>
 </template>
 
@@ -9,3 +14,15 @@ export default {
   name: 'TableLoader',
 };
 </script>
+
+<style lang="scss" scoped>
+.table-loader {
+  display: flex;
+  justify-content: center;
+  padding: 20px 0;
+
+  &__sppiner {
+    color: $color-primary;
+  }
+}
+</style>

--- a/src/plugins/initialization/bootstrap.plugin.js
+++ b/src/plugins/initialization/bootstrap.plugin.js
@@ -7,7 +7,6 @@ import {
   NavbarPlugin,
   BreadcrumbPlugin,
   ButtonPlugin,
-  SpinnerPlugin,
   CardPlugin,
   FormPlugin,
   FormCheckboxPlugin,
@@ -24,7 +23,6 @@ Vue.use(DropdownPlugin);
 Vue.use(NavbarPlugin);
 Vue.use(BreadcrumbPlugin);
 Vue.use(ButtonPlugin);
-Vue.use(SpinnerPlugin);
 Vue.use(CardPlugin);
 Vue.use(FormPlugin);
 Vue.use(FormCheckboxPlugin);


### PR DESCRIPTION
## Summary
- remove spinner from `bootstrap`
- use spinner for `TableLoader` from `@fortawesome/vue-fontawesome`

### Issue
Fix loader for tables

### Screenshots
![image](https://user-images.githubusercontent.com/60401137/118093312-eff2ba00-b3d5-11eb-8916-1a90c108ebe6.png)
