### PR TITLE
update tables sort

### DIFF
--- a/src/components/AccountsList.vue
+++ b/src/components/AccountsList.vue
@@ -3,6 +3,7 @@
     class="accounts-list"
     request-name="getAccounts"
     :fields="fields"
+    is-sort-via-api-enabled
   >
     <template #cell(number)="{ index }">
       {{ index + 1 }}

--- a/src/components/BlocksList.vue
+++ b/src/components/BlocksList.vue
@@ -58,19 +58,14 @@ export default {
     fields: {
       type: Array,
       default: () => [
-        { key: 'level', label: 'Height', sortable: true },
+        { key: 'level', label: 'Height' },
         { key: 'hash', label: 'Block hash' },
         { key: 'proposer', label: 'Proposer' },
         { key: 'number_of_signatures', label: 'Signatures' },
-        {
-          key: 'number_of_txs',
-          label: '# of Ops',
-          sortable: true,
-          class: 'cell-center',
-        },
+        { key: 'number_of_txs', label: '# of Ops', class: 'cell-center' },
         { key: 'epoch', label: 'Epoch' },
         { key: 'fees', label: 'Fees' },
-        { key: 'timestamp', label: 'Date', sortable: true },
+        { key: 'timestamp', label: 'Date' },
       ],
     },
     listFetchParams: {

--- a/src/components/OperationsList.vue
+++ b/src/components/OperationsList.vue
@@ -232,11 +232,11 @@ export default {
         { key: 'hash', label: 'Operation Hash' },
         { key: 'from', label: 'From' },
         { key: 'to', label: 'To' },
-        { key: 'amount', label: 'Amount', sortable: true },
+        { key: 'amount', label: 'Amount' },
         { key: 'nonce', label: 'Nonce' },
         { key: 'status', label: 'Status' },
         { key: 'type', label: 'Type' },
-        { key: 'timestamp', label: 'Date', sortable: true },
+        { key: 'timestamp', label: 'Date' },
       ],
     },
     filters: {

--- a/src/components/ValidatorsList.vue
+++ b/src/components/ValidatorsList.vue
@@ -3,6 +3,8 @@
     class="validators-list"
     request-name="getValidators"
     :fields="fields"
+    :fetch-params="fetchParams"
+    :is-fetch-on-scroll-enabled="false"
   >
     <template #cell(number)="{ index }">
       {{ index + 1 }}
@@ -109,6 +111,9 @@ export default {
         { key: 'status', label: 'Status', class: 'cell-center' },
         { key: 'validate_since', label: 'Registered', sortable: true },
       ],
+      fetchParams: {
+        limit: 200,
+      },
     };
   },
 };

--- a/src/views/Account.vue
+++ b/src/views/Account.vue
@@ -545,16 +545,16 @@ export default {
             { key: 'level', label: 'Height' },
             { key: 'hash', label: 'Operation hash' },
             { key: 'type', label: 'Type' },
-            { key: 'escrow_amount', label: 'Escrow amount', sortable: true },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'escrow_amount', label: 'Escrow amount' },
+            { key: 'timestamp', label: 'Date' },
           ];
         case 'other':
           return [
             { key: 'level', label: 'Height' },
             { key: 'hash', label: 'Operation hash' },
             { key: 'type', label: 'Type' },
-            { key: 'escrow_amount', label: 'Escrow amount', sortable: true },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'escrow_amount', label: 'Escrow amount' },
+            { key: 'timestamp', label: 'Date' },
           ];
         case 'transfers':
         default:
@@ -563,8 +563,8 @@ export default {
             { key: 'hash', label: 'Transaction hash' },
             { key: 'from', label: 'From' },
             { key: 'to', label: 'To' },
-            { key: 'amount', label: 'Amount', sortable: true },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'amount', label: 'Amount' },
+            { key: 'timestamp', label: 'Date' },
           ];
       }
     },

--- a/src/views/Validator.vue
+++ b/src/views/Validator.vue
@@ -669,32 +669,32 @@ export default {
             { key: 'level', label: 'Height' },
             { key: 'hash', label: 'Operation hash' },
             { key: 'type', label: 'Type' },
-            { key: 'escrow_amount', label: 'Escrow amount', sortable: true },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'escrow_amount', label: 'Escrow amount' },
+            { key: 'timestamp', label: 'Date' },
           ];
         case 'other':
           return [
             { key: 'level', label: 'Height' },
             { key: 'hash', label: 'Hash' },
-            { key: 'amount', label: 'Amount', sortable: true },
+            { key: 'amount', label: 'Amount' },
             { key: 'from', label: 'From' },
             { key: 'to', label: 'To' },
             { key: 'nonce', label: 'Nonce' },
             { key: 'type', label: 'Type' },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'timestamp', label: 'Date' },
           ];
         case 'delegators':
           return [
             { key: 'account_id', label: 'Account' },
-            { key: 'escrow_amount', label: 'Escrow amount', sortable: true },
-            { key: 'delegate_since', label: 'Delegate since', sortable: true },
+            { key: 'escrow_amount', label: 'Escrow amount' },
+            { key: 'delegate_since', label: 'Delegate since' },
           ];
         case 'rewards':
           return [
             { key: 'block_level', label: 'Height' },
             { key: 'epoch', label: 'Epoch' },
-            { key: 'amount', label: 'Amount', sortable: true },
-            { key: 'created_at', label: 'Date', sortable: true },
+            { key: 'amount', label: 'Amount' },
+            { key: 'created_at', label: 'Date' },
           ];
         case 'transfers':
         default:
@@ -703,8 +703,8 @@ export default {
             { key: 'hash', label: 'Transaction hash' },
             { key: 'from', label: 'From' },
             { key: 'to', label: 'To' },
-            { key: 'amount', label: 'Amount', sortable: true },
-            { key: 'timestamp', label: 'Date', sortable: true },
+            { key: 'amount', label: 'Amount' },
+            { key: 'timestamp', label: 'Date' },
           ];
       }
     },


### PR DESCRIPTION
## Summary
- remove sorting option from all tables, besides `ValidatorsList` and `AccountsLists`
- fetch all validators from API and add ability to sort them locally
- accounts are still sorted via API
- update `CommonTable`

### Issue
- update ability to sort tables